### PR TITLE
Handling merge sql with multiple matched/not matched clauses in Databricks

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -77,13 +77,15 @@ class Databricks(Spark):
         def merge_sql(self, expression: exp.Merge) -> str:
             # In Databricks SQL's merge into implementation, matched clause has to be the first clause
             expression = expression.copy()
+            matched_clause_index = -1
             for i in range(len(expression.expressions)):
                 exp = expression.expressions[i]
                 if exp.args['matched']:
                     matched_clause_index = i
-            matched_clause = expression.expressions[matched_clause_index]
-            expression.expressions[matched_clause_index] = expression.expressions[0]
-            expression.expressions[0] = matched_clause
+            if matched_clause_index >= 1:
+                matched_clause = expression.expressions[matched_clause_index]
+                expression.expressions[matched_clause_index] = expression.expressions[0]
+                expression.expressions[0] = matched_clause
 
             return super().merge_sql(expression)
 

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -80,7 +80,7 @@ class Databricks(Spark):
             # In Databricks SQL's merge into implementation, the statement has to follow the order of: MATCHED clauses, NOT MATCHED [BY TARGET], NOT MATCHED [BY SOURCE]
             # When there are multiple MATCHED clauses, only the last MATCHED clause can OMIT additional conditions
             # When there are multiple NOT MATCHED [BY TARGET] clauses, only the last NOT MATCHED [BY TARGET] clause can OMIT additional conditions
-            # When there are multiple NOT MATCHED [BY SOURCE] clauses, only the last NOT MATCHED [BY TARGET] clause can OMIT additional conditions
+            # When there are multiple NOT MATCHED [BY SOURCE] clauses, only the last NOT MATCHED [BY SOURCE] clause can OMIT additional conditions
 
             sorted_expression = expression.copy()
             matched_clauses_with_conditions: List[int] = []

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -74,6 +74,19 @@ class Databricks(Spark):
             expression.set("this", True)  # trigger ALWAYS in super class
             return super().generatedasidentitycolumnconstraint_sql(expression)
 
+        def merge_sql(self, expression: exp.Merge) -> str:
+            # In Databricks SQL's merge into implementation, matched clause has to be the first clause
+            expression = expression.copy()
+            for i in range(len(expression.expressions)):
+                exp = expression.expressions[i]
+                if exp.args['matched']:
+                    matched_clause_index = i
+            matched_clause = expression.expressions[matched_clause_index]
+            expression.expressions[matched_clause_index] = expression.expressions[0]
+            expression.expressions[0] = matched_clause
+
+            return super().merge_sql(expression)
+
     class Tokenizer(Spark.Tokenizer):
         HEX_STRINGS = []
 

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import List
+
 from sqlglot import exp, transforms
 from sqlglot.dialects.dialect import parse_date_delta, timestamptrunc_sql
 from sqlglot.dialects.spark import Spark
@@ -75,19 +77,50 @@ class Databricks(Spark):
             return super().generatedasidentitycolumnconstraint_sql(expression)
 
         def merge_sql(self, expression: exp.Merge) -> str:
-            # In Databricks SQL's merge into implementation, matched clause has to be the first clause
-            expression = expression.copy()
-            matched_clause_index = -1
+            # In Databricks SQL's merge into implementation, the statement has to follow the order of: MATCHED clauses, NOT MATCHED [BY TARGET], NOT MATCHED [BY SOURCE]
+            # When there are multiple MATCHED clauses, only the last MATCHED clause can OMIT additional conditions
+            # When there are multiple NOT MATCHED [BY TARGET] clauses, only the last NOT MATCHED [BY TARGET] clause can OMIT additional conditions
+            # When there are multiple NOT MATCHED [BY SOURCE] clauses, only the last NOT MATCHED [BY TARGET] clause can OMIT additional conditions
+
+            sorted_expression = expression.copy()
+            matched_clauses_with_conditions: List[int] = []
+            matched_clauses_no_conditions: List[int] = []
+            not_matched_clauses_by_target_with_conditions: List[int] = []
+            not_matched_clauses_by_target_no_conditions: List[int] = []
+            not_matched_clauses_by_source_with_conditions: List[int] = []
+            not_matched_clauses_by_source_no_conditions: List[int] = []
+            sorted_index = [
+                matched_clauses_with_conditions,
+                matched_clauses_no_conditions,
+                not_matched_clauses_by_target_with_conditions,
+                not_matched_clauses_by_target_no_conditions,
+                not_matched_clauses_by_source_with_conditions,
+                not_matched_clauses_by_source_no_conditions,
+            ]
             for i in range(len(expression.expressions)):
                 exp = expression.expressions[i]
-                if exp.args['matched']:
-                    matched_clause_index = i
-            if matched_clause_index >= 1:
-                matched_clause = expression.expressions[matched_clause_index]
-                expression.expressions[matched_clause_index] = expression.expressions[0]
-                expression.expressions[0] = matched_clause
+                if exp.args["matched"]:
+                    if exp.args["condition"] is None:
+                        matched_clauses_no_conditions.append(i)
+                    else:
+                        matched_clauses_with_conditions.append(i)
+                elif exp.args["source"]:
+                    if exp.args["condition"] is None:
+                        not_matched_clauses_by_source_no_conditions.append(i)
+                    else:
+                        not_matched_clauses_by_source_with_conditions.append(i)
+                else:  # NOT MATCHED BY TARGET
+                    if exp.args["condition"] is None:
+                        not_matched_clauses_by_target_no_conditions.append(i)
+                    else:
+                        not_matched_clauses_by_target_with_conditions.append(i)
+            curse = 0
+            for index_group in sorted_index:
+                for index in index_group:
+                    sorted_expression.expressions[curse] = expression.expressions[index]
+                    curse += 1
 
-            return super().merge_sql(expression)
+            return super().merge_sql(sorted_expression)
 
     class Tokenizer(Spark.Tokenizer):
         HEX_STRINGS = []

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -204,7 +204,7 @@ class TestDatabricks(Validator):
             T.username = S.username""",
             write={
                 "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
-            }
+            },
         )
         self.validate_all(
             """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
@@ -219,7 +219,7 @@ class TestDatabricks(Validator):
             """,
             write={
                 "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
-            }
+            },
         )
         self.validate_all(
             """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
@@ -231,7 +231,7 @@ class TestDatabricks(Validator):
             """,
             write={
                 "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
-            }
+            },
         )
         self.validate_all(
             """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
@@ -246,5 +246,109 @@ class TestDatabricks(Validator):
             """,
             write={
                 "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED AND T.username IS NULL THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
-            }
+            },
+        )
+        # more test cases on multiple matched clauses
+        self.validate_all(
+            """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
+            USING common..t_reporting_user_merge AS S
+            ON (T.user_id = S.user_id)
+            WHEN MATCHED
+            THEN UPDATE SET
+            T.username = S.username
+            WHEN MATCHED AND S.username = 'xyx'
+            THEN UPDATE SET
+            T.username = 'yxy'
+            WHEN NOT MATCHED BY TARGET
+            THEN INSERT(user_id, username)
+            VALUES(s.user_id, s.username)
+            """,
+            write={
+                "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED AND S.username = 'xyx' THEN UPDATE SET T.username = 'yxy' WHEN MATCHED THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
+            },
+        )
+        self.validate_all(
+            """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
+            USING common..t_reporting_user_merge AS S
+            ON (T.user_id = S.user_id)
+            WHEN MATCHED AND S.username = 'xyx'
+            THEN UPDATE SET
+            T.username = 'yxy'
+            WHEN MATCHED
+            THEN UPDATE SET
+            T.username = S.username
+            WHEN NOT MATCHED BY TARGET
+            THEN INSERT(user_id, username)
+            VALUES(s.user_id, s.username)
+            """,
+            write={
+                "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED AND S.username = 'xyx' THEN UPDATE SET T.username = 'yxy' WHEN MATCHED THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
+            },
+        )
+        self.validate_all(
+            """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
+            USING common..t_reporting_user_merge AS S
+            ON (T.user_id = S.user_id)
+            WHEN MATCHED
+            THEN UPDATE SET
+            T.username = S.username
+            WHEN NOT MATCHED BY TARGET
+            THEN INSERT(user_id, username)
+            VALUES(s.user_id, s.username)
+            WHEN MATCHED AND S.username = 'xyx'
+            THEN UPDATE SET
+            T.username = 'yxy'
+            """,
+            write={
+                "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED AND S.username = 'xyx' THEN UPDATE SET T.username = 'yxy' WHEN MATCHED THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
+            },
+        )
+        self.validate_all(
+            """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
+            USING common..t_reporting_user_merge AS S
+            ON (T.user_id = S.user_id)
+            WHEN MATCHED
+            THEN UPDATE SET
+            T.username = S.username
+            WHEN MATCHED AND S.username = 'xyx'
+            THEN UPDATE SET
+            T.username = 'yxy'
+            WHEN NOT MATCHED BY TARGET
+            THEN INSERT(user_id, username)
+            VALUES(s.user_id, s.username)
+            """,
+            write={
+                "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED AND S.username = 'xyx' THEN UPDATE SET T.username = 'yxy' WHEN MATCHED THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
+            },
+        )
+        self.validate_all(
+            """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
+            USING common..t_reporting_user_merge AS S
+            ON (T.user_id = S.user_id)
+
+            WHEN NOT MATCHED BY SOURCE
+            THEN DELETE
+
+            WHEN NOT MATCHED BY SOURCE AND S.username = 'xyx'
+            THEN DELETE
+
+            WHEN MATCHED
+            THEN UPDATE SET
+            T.username = S.username
+
+            WHEN MATCHED AND S.username = 'xyx'
+            THEN UPDATE SET
+            T.username = 'MATCHED'
+
+            WHEN NOT MATCHED AND T.username = 'xyx'
+            THEN INSERT(user_id, username)
+            VALUES(s.user_id, 'NOT MATCHED')
+
+            WHEN NOT MATCHED
+            THEN INSERT(user_id, username)
+            VALUES(s.user_id, s.username)
+            """,
+            write={
+                "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED AND S.username = 'xyx' THEN UPDATE SET T.username = 'MATCHED' WHEN MATCHED THEN UPDATE SET T.username = S.username WHEN NOT MATCHED AND T.username = 'xyx' THEN INSERT (user_id, username) VALUES (s.user_id, 'NOT MATCHED') WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username) WHEN NOT MATCHED BY SOURCE AND S.username = 'xyx' THEN DELETE WHEN NOT MATCHED BY SOURCE THEN DELETE"
+            },
         )

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -190,3 +190,34 @@ class TestDatabricks(Validator):
                 "databricks": "WITH x AS (SELECT 1) SELECT * FROM x",
             },
         )
+
+    def test_merge_into(self):
+        self.validate_all(
+            """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
+            USING common..t_reporting_user_merge AS S
+            ON (T.user_id = S.user_id)
+            WHEN NOT MATCHED BY TARGET
+            THEN INSERT(user_id, username)
+            VALUES(s.user_id, s.username)
+            WHEN MATCHED
+            THEN UPDATE SET
+            T.username = S.username""",
+            write={
+                "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
+            }
+        )
+        self.validate_all(
+            """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
+            USING common..t_reporting_user_merge AS S
+            ON (T.user_id = S.user_id)
+            WHEN MATCHED
+            THEN UPDATE SET
+            T.username = S.username
+            WHEN NOT MATCHED BY TARGET
+            THEN INSERT(user_id, username)
+            VALUES(s.user_id, s.username)
+            """,
+            write={
+                "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
+            }
+        )

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -221,3 +221,30 @@ class TestDatabricks(Validator):
                 "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
             }
         )
+        self.validate_all(
+            """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
+            USING common..t_reporting_user_merge AS S
+            ON (T.user_id = S.user_id)
+            WHEN NOT MATCHED BY TARGET
+            THEN INSERT(user_id, username)
+            VALUES(s.user_id, s.username)
+            """,
+            write={
+                "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
+            }
+        )
+        self.validate_all(
+            """MERGE common..t_reporting_user WITH (HOLDLOCK) AS T
+            USING common..t_reporting_user_merge AS S
+            ON (T.user_id = S.user_id)
+            WHEN MATCHED AND T.username IS NULL
+            THEN UPDATE SET
+            T.username = S.username
+            WHEN NOT MATCHED BY TARGET
+            THEN INSERT(user_id, username)
+            VALUES(s.user_id, s.username)
+            """,
+            write={
+                "databricks": "MERGE INTO common.t_reporting_user AS T USING common.t_reporting_user_merge AS S ON (T.user_id = S.user_id) WHEN MATCHED AND T.username IS NULL THEN UPDATE SET T.username = S.username WHEN NOT MATCHED THEN INSERT (user_id, username) VALUES (s.user_id, s.username)"
+            }
+        )


### PR DESCRIPTION
- In Databricks SQL's merge into implementation, the statement has to follow the order of: MATCHED clauses, NOT MATCHED [BY TARGET], NOT MATCHED [BY SOURCE]
- When there are multiple MATCHED clauses, only the last MATCHED clause can OMIT additional conditions
- When there are multiple NOT MATCHED [BY TARGET] clauses, only the last NOT MATCHED [BY TARGET] clause can OMIT additional conditions
- When there are multiple NOT MATCHED [BY SOURCE] clauses, only the last NOT MATCHED [BY TARGET] clause can OMIT additional conditions